### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,28 @@
+name: Release Python Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: github.repository == 'carbonplan/pangeo-forge-bigquery'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade setuptools setuptools-scm build twine
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: "__token__"
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          python -m build
+          twine check dist/*
+          twine upload dist/*


### PR DESCRIPTION
Can we release an initial version of this package, so we can use a pinned version in https://github.com/leap-stc/cmip6-leap-feedstock/pull/61 ?

TODO:
- Create a `PYPI_TOKEN` repo secret. I can add that from my account for now if that's convenient (@norlandrhagen can you give me admin access here?)
- Merge this
- Release v0.0.1 ?